### PR TITLE
[Feat] navigation bar controller 달기

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="JDK" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="JDK" project-jdk-type="JavaSDK" />
   <component name="ProjectType">
     <option name="id" value="io.flutter" />
   </component>

--- a/bandi_official.iml
+++ b/bandi_official.iml
@@ -34,6 +34,7 @@
       <excludeFolder url="file://$MODULE_DIR$/windows/flutter/ephemeral/.plugin_symlinks/firebase_storage/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/windows/flutter/ephemeral/.plugin_symlinks/firebase_storage/build" />
     </content>
+    <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />

--- a/lib/components/noreuse/homeTopBar.dart
+++ b/lib/components/noreuse/homeTopBar.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
+
+Widget homeTopBar() {
+  return Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 24.0),
+    child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          PhosphorIcon(PhosphorIcons.speakerSimpleHigh(
+              PhosphorIconsStyle.fill),
+            color: Colors.white,),
+          PhosphorIcon(PhosphorIcons.envelopeSimple(
+              PhosphorIconsStyle.fill),
+            color: Colors.white,)
+        ]),
+  );
+}

--- a/lib/components/noreuse/navigationbar.dart
+++ b/lib/components/noreuse/navigationbar.dart
@@ -1,27 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
+import 'package:provider/provider.dart';
 
-Widget navigationBar() {
-  return Container(
-    decoration: BoxDecoration(
+import '../../controller/navigationToggleProvider.dart';
+
+Widget navigationBar(BuildContext context) {
+  final navigationToggleProvider = Provider.of<NavigationToggleProvider>(context);
+
+  return Center(
+    child: Container(
+      decoration: BoxDecoration(
         border: Border.all(width: 1, color: Colors.white),
-        borderRadius: BorderRadius.circular(30)
-    ),
-    child: Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          PhosphorIcon(
-            PhosphorIcons.houseSimple(),
-            color: Colors.white,
-          ),
-          const SizedBox(width: 24,),
-          PhosphorIcon(
-            PhosphorIcons.book(),
-            color: Colors.white,
-          )
-        ],
+        borderRadius: BorderRadius.circular(30),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GestureDetector(
+              onTap: () {
+                navigationToggleProvider.selectIndex(0);
+              },
+              child: PhosphorIcon(
+                navigationToggleProvider.selectedIndex == 0
+                    ? PhosphorIcons.houseSimple(PhosphorIconsStyle.fill)
+                    : PhosphorIcons.houseSimple(PhosphorIconsStyle.regular),
+                color: Colors.white,
+              ),
+            ),
+            const SizedBox(width: 24),
+            GestureDetector(
+              onTap: () {
+                navigationToggleProvider.selectIndex(1);
+              },
+              child: PhosphorIcon(
+                navigationToggleProvider.selectedIndex == 1
+                    ? PhosphorIcons.book(PhosphorIconsStyle.fill)
+                    : PhosphorIcons.book(PhosphorIconsStyle.regular),
+                color: Colors.white,
+              ),
+            ),
+          ],
+        ),
       ),
     ),
   );

--- a/lib/controller/navigationToggleProvider.dart
+++ b/lib/controller/navigationToggleProvider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class NavigationToggleProvider with ChangeNotifier {
+  // _selectedIndex == 0 : home
+  // _selectedIndex == 1 : book
+  int _selectedIndex = 0;
+
+  int get selectedIndex => _selectedIndex;
+
+  void selectIndex(int index) {
+    _selectedIndex = index;
+    notifyListeners();
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:bandi_official/theme/custom_theme_data.dart';
 import 'package:bandi_official/theme/custom_theme_mode.dart';
-import 'package:bandi_official/view/homePage.dart';
+import 'package:bandi_official/view/navigation.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:provider/provider.dart';
+import 'controller/navigationToggleProvider.dart';
 import 'firebase_options.dart';
 import 'package:flutter/material.dart';
 
@@ -33,7 +35,9 @@ class MainApp extends StatelessWidget {
           darkTheme: CustomThemeData.dark,
           theme: CustomThemeData.light,
           themeMode: CustomThemeMode.themeMode.value,
-          home: const HomePage(),
+          home: ChangeNotifierProvider(
+              create: (context) => NavigationToggleProvider(),
+              child: const Navigation()),
         );
       },
     );

--- a/lib/view/homePage.dart
+++ b/lib/view/homePage.dart
@@ -1,30 +1,15 @@
 import 'package:flutter/material.dart';
-import '../components/noreuse/navigationbar.dart';
+
+import '../components/noreuse/homeTopBar.dart';
 
 class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+  const HomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: const BoxDecoration(
-        image: DecorationImage(
-          fit: BoxFit.cover,
-          image: AssetImage('assets/images/backgrounds/background.png'), // 배경 이미지
-        ),
-      ),
-      child: SafeArea(
-        child: Scaffold(
-          backgroundColor: Colors.transparent,
-          body: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Container(),
-              navigationBar()
-            ],
-          )
-        ),
-      ),
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: homeTopBar(),
     );
   }
 }

--- a/lib/view/listPage.dart
+++ b/lib/view/listPage.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ListPage extends StatelessWidget {
+  const ListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Center(child: Text("1")),
+    );
+  }
+}

--- a/lib/view/navigation.dart
+++ b/lib/view/navigation.dart
@@ -1,0 +1,39 @@
+import 'package:bandi_official/view/homePage.dart';
+import 'package:bandi_official/view/listPage.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../components/noreuse/navigationbar.dart';
+import '../controller/navigationToggleProvider.dart';
+
+class Navigation extends StatelessWidget {
+  const Navigation({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final navigationToggleProvider =
+        Provider.of<NavigationToggleProvider>(context);
+
+    return Container(
+      decoration: const BoxDecoration(
+        image: DecorationImage(
+          fit: BoxFit.cover,
+          image:
+              AssetImage('assets/images/backgrounds/background.png'), // 배경 이미지
+        ),
+      ),
+      child: SafeArea(
+        child: Scaffold(
+            backgroundColor: Colors.transparent,
+            body: Stack(children: [
+              navigationToggleProvider.selectedIndex == 0
+                  ? const HomePage()
+                  : const ListPage(),
+              Column(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [navigationBar(context)],
+              ),
+            ])),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

[ISSUE] 폴더나 파일 naming #6

## 📝작업 내용

> 네비게이션바에 provider 써서 toggle 기능을 달았고 stack으로 뒷 페이지들을 움직이게 했음
> home의 노래나 메일함도 아이콘만 넣어둠

### 스크린샷 (선택)
<img src="https://github.com/Nein-to-Sick/bandi_official/assets/63464299/1660661f-dbc5-4b72-a7c1-81b144cc1f96" alt="Navigation Bar" width="300"/>
<img src="https://github.com/Nein-to-Sick/bandi_official/assets/63464299/679ce9c1-3a0f-4011-99c5-0a875d875a48" alt="Navigation Bar" width="300"/>


## 💬리뷰 요구사항(선택)
> 폴더 파일 사전 네이밍 필요

