### PR TITLE
[Feat] ThemeData 색상 및 폰트 변경

### DIFF
--- a/lib/theme/custom_theme_data.dart
+++ b/lib/theme/custom_theme_data.dart
@@ -1,46 +1,82 @@
 import 'package:flutter/material.dart';
 
 class BandiColor {
-  static Color primaryColor(BuildContext context) {
+  /// Black Color
+  static Color foundationColor100(BuildContext context) {
     return Theme.of(context).colorScheme.primary;
   }
 
-  static Color backgroundColor(BuildContext context) {
+  /// Black Color
+  static Color foundationColor80(BuildContext context) {
+    return Theme.of(context).colorScheme.primary.withOpacity(0.8);
+  }
+
+  /// Black Color
+  static Color foundationColor60(BuildContext context) {
+    return Theme.of(context).colorScheme.primary.withOpacity(0.6);
+  }
+
+  /// Black Color
+  static Color foundationColor40(BuildContext context) {
+    return Theme.of(context).colorScheme.primary.withOpacity(0.4);
+  }
+
+  /// Black Color
+  static Color foundationColor20(BuildContext context) {
+    return Theme.of(context).colorScheme.primary.withOpacity(0.2);
+  }
+
+  /// Black Color
+  static Color foundationColor10(BuildContext context) {
+    return Theme.of(context).colorScheme.primary.withOpacity(0.1);
+  }
+
+  /// Neutral Color
+  static Color neutralColor100(BuildContext context) {
     return Theme.of(context).colorScheme.surface;
   }
 
-  static Color accentColor(BuildContext context) {
+  /// Neutral Color
+  static Color neutralColor90(BuildContext context) {
+    return Theme.of(context).colorScheme.surface.withOpacity(0.9);
+  }
+
+  /// Neutral Color
+  static Color neutralColor80(BuildContext context) {
+    return Theme.of(context).colorScheme.surface.withOpacity(0.8);
+  }
+
+  /// Neutral Color
+  static Color neutralColor60(BuildContext context) {
+    return Theme.of(context).colorScheme.surface.withOpacity(0.6);
+  }
+
+  /// Neutral Color
+  static Color neutralColor40(BuildContext context) {
+    return Theme.of(context).colorScheme.surface.withOpacity(0.4);
+  }
+
+  /// Neutral Color
+  static Color neutralColor20(BuildContext context) {
+    return Theme.of(context).colorScheme.surface.withOpacity(0.2);
+  }
+
+  /// Neutral Color
+  static Color neutralColor10(BuildContext context) {
+    return Theme.of(context).colorScheme.surface.withOpacity(0.1);
+  }
+
+  /// Accent Color
+  static Color accentColorYellow(BuildContext context) {
     return Theme.of(context).colorScheme.secondary;
   }
 
-  static Color errorColor(BuildContext context) {
+  /// Accent Color
+  static Color accentColorRed(BuildContext context) {
     return Theme.of(context).colorScheme.error;
   }
 
-  static Color gray001Color(BuildContext context) {
-    return Theme.of(context).disabledColor;
-  }
-
-  static Color gray002Color(BuildContext context) {
-    return Theme.of(context).dividerColor;
-  }
-
-  static Color gray003Color(BuildContext context) {
-    return Theme.of(context).focusColor;
-  }
-
-  static Color gray004Color(BuildContext context) {
-    return Theme.of(context).highlightColor;
-  }
-
-  static Color gray005Color(BuildContext context) {
-    return Theme.of(context).hintColor;
-  }
-
-  static Color gray006Color(BuildContext context) {
-    return Theme.of(context).hoverColor;
-  }
-
+  /// Transparent Color
   static Color transparent(BuildContext context) {
     return Colors.transparent;
   }
@@ -98,13 +134,19 @@ class BandiFont {
   static medium(BuildContext context) {}
 }
 
-//  TODO: 추후 색상 수정 필요
 class CustomThemeData {
   static final ThemeData light = ThemeData(
     colorScheme: const ColorScheme.light(
+      /// Foundation
       primary: Color(0xff000000),
+
+      /// Neutral
       surface: Color(0xffFFFFFF),
+
+      /// Accent Yellow
       secondary: Color(0xffFFCB46),
+
+      /// Accent Red
       error: Color(0xffC33025),
       onPrimary: Color(0xffFFFFFF),
       onSurface: Color(0xff000000),
@@ -140,73 +182,86 @@ class CustomThemeData {
     textTheme: textTheme,
   );
 
-  //  TODO: 추후 폰트 수정 필요
   static TextTheme textTheme = const TextTheme(
+    /**Headline1 */
     displayLarge: TextStyle(
       fontFamily: "IBMPlexSansSemiBold",
       fontSize: 28,
       height: 36 / 28,
     ),
+    /**Headline2 */
     displayMedium: TextStyle(
       fontFamily: "IBMPlexSansSemiBold",
       fontSize: 20,
       height: 28 / 20,
     ),
+    /**Headline3 */
     displaySmall: TextStyle(
       fontFamily: "IBMPlexSansSemiBold",
       fontSize: 18,
       height: 24 / 18,
     ),
+    /**Headline4 */
     headlineMedium: TextStyle(
       fontFamily: "IBMPlexSansSemiBold",
       fontSize: 16,
       height: 20 / 16,
     ),
+    /**Body1 */
     titleMedium: TextStyle(
       fontFamily: "IBMPlexSansRegular",
       fontSize: 16,
       height: 24 / 16,
     ),
+    /**Body2 */
     titleSmall: TextStyle(
       fontFamily: "IBMPlexSansRegular",
       fontSize: 14,
       height: 20 / 14,
     ),
+    /**Body3 */
     headlineSmall: TextStyle(
       fontFamily: "IBMPlexSansRegular",
       fontSize: 12,
       height: 16 / 12,
     ),
+    /**Normal */
     bodyLarge: TextStyle(
-      fontFamily: "IBMPlexSansRegular",
+      fontFamily: "IBMPlexSansMedium",
       fontSize: 18,
       height: 24 / 18,
     ),
+    /**Medium */
     bodyMedium: TextStyle(
-      fontFamily: "IBMPlexSansRegular",
+      fontFamily: "IBMPlexSansMedium",
       fontSize: 16,
       height: 20 / 16,
     ),
+    /**Small */
     bodySmall: TextStyle(
-      fontFamily: "IBMPlexSansRegular",
+      fontFamily: "IBMPlexSansMedium",
       fontSize: 14,
       height: 16 / 14,
     ),
+    /**Small2 */
     labelLarge: TextStyle(
-      fontFamily: "IBMPlexSansRegular",
+      fontFamily: "IBMPlexSansSemiBold",
       fontSize: 11,
       height: 22 / 11,
     ),
+    /**Text1 */
     labelMedium: TextStyle(
       fontFamily: "IBMPlexSansRegular",
       fontSize: 16,
       height: 24 / 16,
     ),
+    /**Text2 */
     labelSmall: TextStyle(
       fontFamily: "IBMPlexSansRegular",
       fontSize: 12,
       height: 16 / 12,
     ),
+    /**??? */
     headlineLarge: TextStyle(
       fontFamily: "IBMPlexSansSemiBold",
       fontSize: 16,


### PR DESCRIPTION
1. Foundation, Neutral, Accent 색상 반영
2. 폰트 변경

## #️⃣연관된 이슈

#8 

## 📝작업 내용

> Figma 디자인 내용 기반 ThemeData 적용 및 폰트 변경

![image](https://github.com/user-attachments/assets/1d5b0e59-7bdf-400c-ba3c-7975e1869367)

## 💬리뷰 요구사항(선택)

> 기존 Flutter ThemeData에서 제공하는 변수명(primary, secondary, displayLarge, etc)과 Figma 상의 색상 및 폰트명이 대응되지 않습니다. 이전 버전의 ThemeData 코드를 참고하여 수정하였는데, 문제가 없을지 확인 부탁 드립니다.
