### PR TITLE
[Feat] 편지, 공감한 일기 열람 페이지 추가

### DIFF
--- a/lib/controller/mail_controller.dart
+++ b/lib/controller/mail_controller.dart
@@ -1,0 +1,179 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'dart:developer' as dev;
+
+class MailController with ChangeNotifier {
+  final FirebaseFirestore firestore = FirebaseFirestore.instance;
+  DocumentSnapshot? lastDocumentForLetter;
+  DocumentSnapshot? lastDocumentForlikedDiary;
+
+  // Get current user from FirebaseAuth
+  User? get currentUser => FirebaseAuth.instance.currentUser;
+
+  // Last fetched index for pagination
+  int _lastFetchedIndex = 0;
+  // maximun fetch limit
+  int fetchItemLimit = 10;
+
+  Stream<List<DocumentSnapshot>> getLettersStream() {
+    final user = currentUser;
+    if (user == null) {
+      throw Exception('User is not logged in');
+    }
+    return firestore
+        .collection('users')
+        //.doc(userId!.uid)
+        .doc('21jPhIHrf7iBwVAh92ZW')
+        .collection('letters')
+        .orderBy('date', descending: true)
+        .limit(fetchItemLimit)
+        .snapshots()
+        .map((snapshot) => snapshot.docs);
+  }
+
+  Future<List<DocumentSnapshot>> fetchLetters() async {
+    final user = currentUser;
+    if (user == null) {
+      throw Exception('User is not logged in');
+    }
+
+    Query query = firestore
+        .collection('users')
+        //.doc(currentUser!.uid)
+        .doc('21jPhIHrf7iBwVAh92ZW')
+        .collection('letters')
+        .orderBy('date', descending: true)
+        .limit(fetchItemLimit);
+
+    if (lastDocumentForLetter != null) {
+      query = query.startAfterDocument(lastDocumentForLetter!);
+    }
+
+    QuerySnapshot querySnapshot = await query.get();
+
+    // Update lastDocumentForLetter for the next fetch
+    if (querySnapshot.docs.isNotEmpty) {
+      lastDocumentForLetter = querySnapshot.docs.last;
+    }
+
+    return querySnapshot.docs;
+  }
+
+  Future<void> deleteLetter(String letterId) async {
+    final user = currentUser;
+    if (user == null) {
+      throw Exception('User is not logged in');
+    }
+
+    try {
+      await firestore
+          .collection('users')
+          //.doc(currentUser!.uid)
+          .doc('21jPhIHrf7iBwVAh92ZW')
+          .collection('letters')
+          .doc(letterId)
+          .delete();
+    } catch (e) {
+      dev.log("Error deleting letter: $e");
+    }
+  }
+
+  // Stream to fetch the first 10 likedDiaryId items and their corresponding documents from 'allDiary'
+  Stream<List<DocumentSnapshot>> getLikedDiariesStream() async* {
+    final user = currentUser;
+    if (user == null) {
+      throw Exception('User is not logged in');
+    }
+
+    try {
+      // Get the likedDiaryIds from the user's document
+      DocumentSnapshot userDoc = await firestore
+          .collection('users') //.doc(currentUser!.uid)
+          .doc('21jPhIHrf7iBwVAh92ZW')
+          .get();
+
+      List<String> likedDiaryIds = List<String>.from(userDoc['likedDiaryId']);
+
+      // First 10 likedDiaryIds
+      List<String> firstLikedDiaryIds =
+          likedDiaryIds.take(fetchItemLimit).toList();
+
+      if (firstLikedDiaryIds.isNotEmpty) {
+        Query query = firestore
+            .collection('allDiary')
+            .where(FieldPath.documentId, whereIn: firstLikedDiaryIds)
+            .orderBy('createdAt', descending: true);
+
+        QuerySnapshot querySnapshot = await query.get();
+        // Update the lastDocument with the last fetched document
+        if (querySnapshot.docs.isNotEmpty) {
+          lastDocumentForlikedDiary = querySnapshot.docs.last;
+        }
+
+        yield querySnapshot.docs;
+      } else {
+        yield [];
+      }
+    } catch (e) {
+      dev.log("Error fetching liked diaries: $e");
+      yield [];
+    }
+  }
+
+  Future<List<DocumentSnapshot>> fetchLikedDiaries() async {
+    final user = currentUser;
+    if (user == null) {
+      throw Exception('User is not logged in');
+    }
+
+    if (lastDocumentForlikedDiary == null) {
+      return [];
+    }
+
+    DocumentSnapshot userDoc = await firestore
+        .collection('users') //.doc(currentUser!.uid)
+        .doc('21jPhIHrf7iBwVAh92ZW')
+        .get();
+
+    List<String> likedDiaryIds = List<String>.from(userDoc['likedDiaryId']);
+    List<String> nextLikedDiaryIds =
+        likedDiaryIds.skip(_lastFetchedIndex).take(fetchItemLimit).toList();
+
+    Query query = firestore
+        .collection('allDiary')
+        .where(FieldPath.documentId, whereIn: nextLikedDiaryIds)
+        .orderBy('createdAt', descending: true)
+        .limit(fetchItemLimit);
+
+    QuerySnapshot querySnapshot = await query.get();
+
+    if (querySnapshot.docs.isNotEmpty) {
+      lastDocumentForlikedDiary = querySnapshot.docs.last;
+    }
+
+    // Update index for the next fetch
+    _lastFetchedIndex += fetchItemLimit;
+
+    return querySnapshot.docs;
+  }
+
+  // Delete a single likedDiaryId array item
+  Future<void> deleteLikedDiary(String diaryId) async {
+    final user = currentUser;
+    if (user == null) {
+      throw Exception('User is not logged in');
+    }
+
+    try {
+      await firestore
+          .collection('users') //.doc(currentUser!.uid)
+          .doc('21jPhIHrf7iBwVAh92ZW')
+          .update({
+        'likedDiaryId': FieldValue.arrayRemove([diaryId]),
+      });
+    } catch (e) {
+      dev.log("Error deleting liked diary: $e");
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:bandi_official/controller/diary_ai_analysis_controller.dart';
 import 'package:bandi_official/controller/diary_ai_chat_controller.dart';
+import 'package:bandi_official/controller/mail_controller.dart';
 import 'package:bandi_official/theme/custom_theme_data.dart';
 import 'package:bandi_official/theme/custom_theme_mode.dart';
 import 'package:bandi_official/view/navigation.dart';
@@ -57,6 +58,9 @@ class MainApp extends StatelessWidget {
               ),
               ChangeNotifierProvider(
                 create: (context) => HomeToWrite(),
+              ),
+              ChangeNotifierProvider(
+                create: (context) => MailController(),
               ),
             ],
             child: const Navigation(),

--- a/lib/view/mail/letters_view.dart
+++ b/lib/view/mail/letters_view.dart
@@ -1,0 +1,72 @@
+import 'package:bandi_official/controller/mail_controller.dart';
+import 'package:bandi_official/theme/custom_theme_data.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'dart:developer' as dev;
+
+class MyLettersPage extends StatelessWidget {
+  const MyLettersPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    MailController mailController = context.watch<MailController>();
+    return Padding(
+      padding: const EdgeInsets.only(top: 7),
+      child: StreamBuilder(
+        stream: mailController.getLettersStream(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('No letters available.'));
+          }
+
+          final letters = snapshot.data!;
+
+          return ListView.builder(
+            itemCount: letters.length,
+            itemBuilder: (context, index) {
+              final letter = letters[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: GestureDetector(
+                  // 편지 열람 기능 추가
+                  onTap: () {},
+                  child: Container(
+                    color: Colors.transparent,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(letter['title'] ?? '제목 없음',
+                            style: BandiFont.headlineMedium(context)?.copyWith(
+                                color: BandiColor.neutralColor100(context))),
+                        const SizedBox(height: 8),
+                        Text(
+                          letter['content'] ?? '내용 없음',
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: BandiFont.headlineSmall(context)?.copyWith(
+                              color: BandiColor.neutralColor60(context)),
+                        ),
+                        const SizedBox(height: 16),
+                        Divider(
+                          color: BandiColor.neutralColor20(context),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/view/mail/liked_diary_view.dart
+++ b/lib/view/mail/liked_diary_view.dart
@@ -1,0 +1,97 @@
+import 'package:bandi_official/controller/mail_controller.dart';
+import 'package:bandi_official/theme/custom_theme_data.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+class LikedDiaryPage extends StatelessWidget {
+  const LikedDiaryPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    MailController mailController = context.watch<MailController>();
+    return Padding(
+      padding: const EdgeInsets.only(top: 7),
+      child: StreamBuilder(
+        stream: mailController.getLikedDiariesStream(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('No diarys available.'));
+          }
+
+          final diarys = snapshot.data!;
+
+          return ListView.builder(
+            itemCount: diarys.length,
+            itemBuilder: (context, index) {
+              final diary = diarys[index];
+              String combinedEmotions =
+                  (diary['emotion'] as List<dynamic>).join(', ');
+              return Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: GestureDetector(
+                  // 일기 열람 기능 추가
+                  onTap: () {},
+                  child: Container(
+                    color: Colors.transparent,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(diary['title'] ?? '제목 없음',
+                            style: BandiFont.headlineMedium(context)?.copyWith(
+                                color: BandiColor.neutralColor100(context))),
+                        const SizedBox(height: 8),
+                        Text(
+                          diary['content'] ?? '내용 없음',
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: BandiFont.headlineSmall(context)?.copyWith(
+                              color: BandiColor.neutralColor60(context)),
+                        ),
+                        const SizedBox(height: 8),
+                        Row(
+                          children: [
+                            Text(
+                              DateFormat('yyyy.M.d').format(
+                                  (diary['createdAt'] as Timestamp).toDate()),
+                              style: BandiFont.headlineSmall(context)?.copyWith(
+                                  color: BandiColor.neutralColor60(context)),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                combinedEmotions,
+                                style: BandiFont.headlineSmall(context)
+                                    ?.copyWith(
+                                        color:
+                                            BandiColor.neutralColor60(context)),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        Divider(
+                          color: BandiColor.neutralColor20(context),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/view/mail/mail_view.dart
+++ b/lib/view/mail/mail_view.dart
@@ -1,10 +1,73 @@
+import 'package:bandi_official/components/appbar/appbar.dart';
+import 'package:bandi_official/theme/custom_theme_data.dart';
+import 'package:bandi_official/view/mail/letters_view.dart';
+import 'package:bandi_official/view/mail/liked_diary_view.dart';
 import 'package:flutter/material.dart';
+import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class MailView extends StatelessWidget {
   const MailView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: Text("2"));
+    return SafeArea(
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: CustomAppBar(
+          title: '보관함',
+          trailingIcon: PhosphorIcons.x(PhosphorIconsStyle.fill),
+          onLeadingIconPressed: () {},
+          onTrailingIconPressed: () {},
+          disableLeadingButton: false,
+          disableTrailingButton: false,
+          isVisibleLeadingButton: false,
+          isVisibleTrailingButton: false,
+        ),
+        body: Padding(
+          padding: EdgeInsets.only(
+              bottom: MediaQuery.of(context).size.height * 0.1, top: 10),
+          child: DefaultTabController(
+            length: 3,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0),
+              child: Column(
+                children: [
+                  TabBar(
+                    labelColor: BandiColor.neutralColor100(context),
+                    unselectedLabelColor: BandiColor.neutralColor40(context),
+                    labelStyle: BandiFont.headlineMedium(context)?.copyWith(
+                      color: BandiColor.neutralColor100(context),
+                    ),
+                    indicatorColor: BandiColor.neutralColor100(context),
+                    indicatorSize: TabBarIndicatorSize.tab,
+                    dividerColor: BandiColor.neutralColor40(context),
+                    tabs: const [
+                      Tab(text: "전체"),
+                      Tab(text: "편지"),
+                      Tab(text: "공감한 일기"),
+                    ],
+                  ),
+                  const Expanded(
+                    child: TabBarView(
+                      children: [
+                        SingleChildScrollView(
+                            child: Center(
+                                child: Column(
+                          children: [
+                            Text("Screen 1"),
+                          ],
+                        ))),
+                        MyLettersPage(),
+                        LikedDiaryPage(),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,6 @@ dependencies:
   intl: ^0.19.0
   shared_preferences: ^2.3.1
   assets_audio_player: ^3.1.1
-  shared_preferences: ^2.2.3
   google_sign_in_ios: ^5.7.6
 
 
@@ -45,11 +44,8 @@ flutter:
   assets:
    - assets/images/
    - assets/images/backgrounds/
-<<<<<<< Updated upstream
    - assets/images/icons/
-=======
    - assets/images/login/
->>>>>>> Stashed changes
    - assets/fonts/
    - assets/config/
    - assets/bgm/


### PR DESCRIPTION
## 📝작업 내용

> 편지, 공감한 일기 페이지 view 및 데이터 조회 기능 추가
> 리스트를 동적으로 불러오는 기능은 추후에 적용 예정

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/3493a8b4-c768-43a5-86d1-3dd63d125649" alt="Resized Image" width="300">

> 구현된 화면

## 💬리뷰 요구사항(선택)

> 폰트 크기로 TabBar에서 짤리는 부분은 추후에 디자이너 리뷰 및 수정 필요
> 전체 페이지는 기능이 명확하지 않아 아직 미구현
