### PR TITLE
[Feat] 로컬 데이터 읽기 버그 수정

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -22,7 +22,7 @@
 const MAX_DIARY_COUNT = 5;
 const functions = require("firebase-functions");
 const admin = require("firebase-admin");
-const { OpenAI } = require("openai");
+const {OpenAI} = require("openai");
 const moment = require("moment-timezone"); // moment-timezone을 사용해야 합니다.
 const timeZone = "Asia/Seoul"; // 한국 시간대 설정
 
@@ -46,8 +46,8 @@ exports.monthlyDiaryReview = functions.region("asia-northeast3").pubsub.schedule
         const lastDayOfMonth = today.clone().endOf("month"); // 달의 마지막 날을 가져오기
 
         // 오늘과 마지막 날을 읽기 쉬운 형식으로 변환
-        const todayFormatted = today.format("yyyy-MM-dd HH:mm:ssZ"); // moment의 format 사용
-        const lastDayFormatted = lastDayOfMonth.format("yyyy-MM-dd HH:mm:ssZ"); // moment의 format 사용
+        const todayFormatted = today.format("YYYY-MM-DD HH:mm:ssZ");
+        const lastDayFormatted = lastDayOfMonth.format("YYYY-MM-DD HH:mm:ssZ");
 
         // 오늘이 달의 마지막 날인지 확인
         if (today.date() !== lastDayOfMonth.date()) {
@@ -105,8 +105,7 @@ exports.monthlyDiaryReview = functions.region("asia-northeast3").pubsub.schedule
             // TODO: 추후 모델 학습 or 프롬프트 개선 필요
             const systemMessage = {
                 content:
-                    `You are a kind assistant. Write an encouraging letter in Korean, addressing the user by their name (${userDoc.nickname} or '친구'), based on their diary entries and emotions. Conclude the letter without a signature or sender's name.`
-                ,
+                    `You are a kind assistant. Write an encouraging letter in Korean, addressing the user by their name (${userDoc.nickname} or '친구'), based on their diary entries and emotions. Conclude the letter without a signature or sender's name.`,
                 role: "system",
             };
 
@@ -254,10 +253,10 @@ exports.deleteUserDataAndDoc = functions.https.onCall(async (data, context) => {
         await userRef.delete();
 
         console.log(`User document and sub-collections for ${userId} deleted.`);
-        return { success: true };
+        return {success: true};
     } catch (error) {
         console.error(`Error deleting user data: ${userId}`, error);
-        return { success: false, error: error.message };
+        return {success: false, error: error.message};
     }
 });
 
@@ -269,9 +268,9 @@ exports.deleteAuthUser = functions.https.onCall(async (data, context) => {
     try {
         await admin.auth().deleteUser(userId);
         console.log(`Successfully deleted user: ${userId}`);
-        return { success: true };
+        return {success: true};
     } catch (error) {
         console.error(`Error deleting user: ${userId}`, error);
-        return { success: false, error: error.message };
+        return {success: false, error: error.message};
     }
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -22,7 +22,7 @@
 const MAX_DIARY_COUNT = 5;
 const functions = require("firebase-functions");
 const admin = require("firebase-admin");
-const {OpenAI} = require("openai");
+const { OpenAI } = require("openai");
 const moment = require("moment-timezone"); // moment-timezone을 사용해야 합니다.
 const timeZone = "Asia/Seoul"; // 한국 시간대 설정
 
@@ -105,14 +105,14 @@ exports.monthlyDiaryReview = functions.region("asia-northeast3").pubsub.schedule
             // TODO: 추후 모델 학습 or 프롬프트 개선 필요
             const systemMessage = {
                 content:
-                    "You are a helpful assistant. Please write an encouraging and empathetic letter in Korean based on the diary entries and the emotions expressed in them.",
-
+                    `You are a kind assistant. Write an encouraging letter in Korean, addressing the user by their name (${userDoc.nickname} or '친구'), based on their diary entries and emotions. Conclude the letter without a signature or sender's name.`
+                ,
                 role: "system",
             };
 
             const userDiarySet = {
                 content:
-                    `Here are some recent diary entries with their emotions:\n\n${diaryText}`,
+                    `Here are some recent diary entries with their emotions:\n${diaryText}`,
 
                 role: "user",
             };
@@ -254,10 +254,10 @@ exports.deleteUserDataAndDoc = functions.https.onCall(async (data, context) => {
         await userRef.delete();
 
         console.log(`User document and sub-collections for ${userId} deleted.`);
-        return {success: true};
+        return { success: true };
     } catch (error) {
         console.error(`Error deleting user data: ${userId}`, error);
-        return {success: false, error: error.message};
+        return { success: false, error: error.message };
     }
 });
 
@@ -269,9 +269,9 @@ exports.deleteAuthUser = functions.https.onCall(async (data, context) => {
     try {
         await admin.auth().deleteUser(userId);
         console.log(`Successfully deleted user: ${userId}`);
-        return {success: true};
+        return { success: true };
     } catch (error) {
         console.error(`Error deleting user: ${userId}`, error);
-        return {success: false, error: error.message};
+        return { success: false, error: error.message };
     }
 });

--- a/lib/controller/mail_controller.dart
+++ b/lib/controller/mail_controller.dart
@@ -93,16 +93,25 @@ class MailController with ChangeNotifier {
   // while detail view is shown
   bool isDetailViewShowing = false;
 
-  // // for new letter model
-  // late Letter newLetter;
+  // Flag variable indicating whether more data needs to be loaded
+  bool loadMoreLetterData = true;
+  bool loadMoreLikedDiaryData = true;
 
-  // for new letter model
-  late Letter newLetter = Letter(
-    title: 'yyyy년 m월 편지',
-    content: 'test' * 100,
-    date: timestampToLocal(Timestamp.now()),
-    letterId: 'letterId',
-  );
+  // Flag variable to track whether the scroll listener has already been added
+  bool isEveryMailListenerAdded = false;
+  bool isLettersListenerAdded = false;
+  bool isLikedDiaryListenerAdded = false;
+
+  // // for new letter model
+  late Letter newLetter;
+
+  // // for new letter model
+  // late Letter newLetter = Letter(
+  //   title: 'yyyy년 m월 편지',
+  //   content: 'test' * 100,
+  //   date: timestampToLocal(Timestamp.now()),
+  //   letterId: 'letterId',
+  // );
 
   // mail view tab controller
   late TabController _tabController;
@@ -127,7 +136,7 @@ class MailController with ChangeNotifier {
   int get currentIndex => _tabController.index;
 
   // called on initState
-  void loadDataAndSetting() {
+  Future<void> loadDataAndSetting() async {
     if (!loadLikedDiaryDataOnce || !loadLetterDataOnce) {
       toggleLoading(true);
       if (!loadLikedDiaryDataOnce) {
@@ -158,6 +167,41 @@ class MailController with ChangeNotifier {
   // toggle the detail view value
   void toggleDetailView(bool value) {
     isDetailViewShowing = value;
+    notifyListeners();
+  }
+
+  // toggle the loadMoreLetterData value
+  void toggleLoadMoreLetterData(value) {
+    // dev.log('편지 데이터 로드 토글: $value');
+    loadMoreLetterData = value;
+    notifyListeners();
+  }
+
+  // toggle the loadMoreLikedDiaryData value
+  void toggleLoadMoreLikedDiaryData(value) {
+    // dev.log('공감 일기 데이터 로드 토글: $value');
+    loadMoreLikedDiaryData = value;
+    notifyListeners();
+  }
+
+  // toggle the isListenerAdded value
+  void toggleIsEveryMailListenerAdded(value) {
+    // dev.log('모든 메일 리스너 토글: $value');
+    isEveryMailListenerAdded = value;
+    notifyListeners();
+  }
+
+  // toggle the isListenerAdded value
+  void toggleIsLettersListenerAdded(value) {
+    // dev.log('편지 리스너 토글: $value');
+    isLettersListenerAdded = value;
+    notifyListeners();
+  }
+
+  // toggle the isListenerAdded value
+  void toggleIsLikedDiaryListenerAdded(value) {
+    // dev.log('공감 일기 메일리스너 토글: $value');
+    isLikedDiaryListenerAdded = value;
     notifyListeners();
   }
 
@@ -410,17 +454,16 @@ class MailController with ChangeNotifier {
                   'read older liked Diary from local for date ${key.split('_').skip(1).join('_')}');
 
               if (keys.indexOf(key) == 0) {
-                dev.log('there is no more older liked Diary data');
+                dev.log('[2] there is no more older liked Diary data');
                 return false;
               }
               break;
             }
           } else {
             if (keys.indexOf(key) == 0) {
-              dev.log('there is no more older liked Diary data');
+              dev.log('[1] there is no more older liked Diary data');
               return false;
             }
-            break;
           }
         }
       } else {
@@ -646,17 +689,16 @@ class MailController with ChangeNotifier {
                   'read older letter from local for date ${key.split('_').skip(1).join('_')}');
 
               if (keys.indexOf(key) == 0) {
-                dev.log('there is no more older letter data');
+                dev.log('[2] there is no more older letter data');
                 return false;
               }
               break;
             }
           } else {
             if (keys.indexOf(key) == 0) {
-              dev.log('there is no more older letter data');
+              dev.log('[1] there is no more older letter data');
               return false;
             }
-            break;
           }
         }
       } else {

--- a/lib/view/alarm/alarm_view.dart
+++ b/lib/view/alarm/alarm_view.dart
@@ -48,7 +48,9 @@ class AlarmView extends StatelessWidget {
                   padding:
                       const EdgeInsets.symmetric(horizontal: 25, vertical: 10),
                   child: GestureDetector(
-                    onTap: () {},
+                    onTap: () {
+                      // 편지, 공감 페이지 이동
+                    },
                     child: Row(
                       mainAxisSize: MainAxisSize.max,
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/view/mail/liked_diary_view.dart
+++ b/lib/view/mail/liked_diary_view.dart
@@ -16,7 +16,7 @@ class LikedDiaryPage extends StatefulWidget {
 }
 
 class _LikedDiaryPageState extends State<LikedDiaryPage> {
-  bool loadMoreData = true;
+  late MailController mailController;
 
   Widget filterChips(MailController mailController) {
     return Align(
@@ -73,25 +73,43 @@ class _LikedDiaryPageState extends State<LikedDiaryPage> {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      MailController mailController =
-          Provider.of<MailController>(context, listen: false);
+      mailController = Provider.of<MailController>(context, listen: false);
 
-      mailController.loadDataAndSetting();
-      mailController.restoreLikedDiaryScrollPosition();
+      mailController.loadDataAndSetting().then((value) {
+        mailController.restoreLikedDiaryScrollPosition();
 
-      // when screen reached nearly top of the list load more past data
-      mailController.likedDiaryScrollController.addListener(() async {
-        final position = mailController.likedDiaryScrollController.position;
-        if (loadMoreData && position.atEdge && position.pixels != 0) {
-          if (position.userScrollDirection == ScrollDirection.reverse &&
-              position.maxScrollExtent - position.pixels <= 300) {
-            loadMoreData = await mailController.loadMoreLikedDiary();
-          }
+        if (!mailController.isLikedDiaryListenerAdded) {
+          // when screen reached nearly bottom of the list load more past data
+          WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+            mailController.likedDiaryScrollController
+                .addListener(_scrollListener);
+            mailController.toggleIsLikedDiaryListenerAdded(true);
+          });
         }
       });
     });
 
     super.initState();
+  }
+
+  void _scrollListener() async {
+    final position = mailController.likedDiaryScrollController.position;
+    if (mailController.loadMoreLikedDiaryData &&
+        position.atEdge &&
+        position.pixels != 0) {
+      if (position.userScrollDirection == ScrollDirection.reverse &&
+          position.maxScrollExtent - position.pixels <= 300) {
+        mailController.toggleLoadMoreLikedDiaryData(
+            await mailController.loadMoreLikedDiary());
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    mailController.likedDiaryScrollController.removeListener(_scrollListener);
+    mailController.toggleIsLikedDiaryListenerAdded(false);
+    super.dispose();
   }
 
   @override

--- a/lib/view/mail/mail_view.dart
+++ b/lib/view/mail/mail_view.dart
@@ -23,21 +23,27 @@ class _MailViewState extends State<MailView>
   @override
   void initState() {
     super.initState();
-
     mailController = Provider.of<MailController>(context, listen: false);
+
+    // InitState of the ScrollControllers
     mailController!
         .initTabController(this, 3, mailController!.savedCurrentIndex);
+
+    // InitState of the TabController
+    mailController?.initScrollControllers();
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
+  void dispose() {
+    // Dispose of the ScrollControllers
+    mailController!.everyMailScrollController.dispose();
+    mailController!.letterScrollController.dispose();
+    mailController!.likedDiaryScrollController.dispose();
 
-    // BuildContext를 안전하게 사용하여 MailController에 접근
-    mailController = Provider.of<MailController>(context, listen: false);
+    // Dispose of the TabController
+    mailController!.tabController.dispose();
 
-    // mailController 초기화
-    mailController?.initScrollControllers();
+    super.dispose();
   }
 
   @override

--- a/lib/view/navigation.dart
+++ b/lib/view/navigation.dart
@@ -9,7 +9,6 @@ import 'package:bandi_official/view/login/login_view.dart';
 import 'package:bandi_official/view/mail/mail_view.dart';
 import 'package:bandi_official/view/otherDiary.dart';
 import 'package:bandi_official/view/user/user_view.dart';
-import 'package:bandi_official/view/login/login_view.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';


### PR DESCRIPTION
## 📝작업 내용

> 메일함과 ai chat 페이지의 화면 스크롤시 데이터를 불러오는데 있었던 문제 수정

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1df9d08b-89a5-4372-b69e-165eeaefa1ae)

> ai chat의 경우 데이터를 날짜대로 읽는데 있었던 문제 수정. 메일함의 경우 ScrollController의 init, dispose 등 라이프 사이클에 따라 데이터 갱신 등이 안되었던 문제 수정.

## 💬리뷰 요구사항(선택)

> 최장 6일 정도의 데이터를 작성하여 테스트를 진행했습니다. 이보다 더 많은 데이터의 읽기 쓰기에 문제가 없는지 추후에 테스트가 필요합니다.
