### PR TITLE
[Fix] 계정탈퇴시 컬렉션 또한 삭제로 변경 + 온보딩 사진 문제 변경

### DIFF
--- a/lib/view/login/login_view.dart
+++ b/lib/view/login/login_view.dart
@@ -284,10 +284,16 @@ class _LoginViewState extends State<LoginView> {
               ),
             if (_onboarding < 4)
               Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 18.5),
                   child: _onboarding != 4
                       ? Image.asset(
-                          "assets/images/onboarding/onboarding$_onboarding.png")
-                      : Container()),
+                          "assets/images/onboarding/onboarding$_onboarding.png",
+                          fit: BoxFit.contain,
+                        )
+                      : Container(),
+                ),
+              ),
             if (_onboarding < 3)
               CustomSecondaryButton(
                 title: '건너뛰기',

--- a/lib/view/user/user_view.dart
+++ b/lib/view/user/user_view.dart
@@ -269,6 +269,11 @@ class _UserViewState extends State<UserView> {
                         FirebaseFirestore.instance.collection("users");
                     await userCollection.doc(user.uid).delete();
 
+                    // Firestore의 userDataCollection에서 사용자 데이터 삭제
+                    final userDataCollection = FirebaseFirestore.instance
+                        .collection("userDataCollection");
+                    await userDataCollection.doc(user.uid).delete();
+
                     // Firebase에서 사용자 삭제
                     await user.delete();
 
@@ -282,7 +287,7 @@ class _UserViewState extends State<UserView> {
                         Provider.of<NavigationToggleProvider>(context,
                             listen: false);
                     navigationToggleProvider.selectIndex(-1); // 로그인 페이지로 이동
-                    log("게정 탈퇴 완료");
+                    log("계정 탈퇴 완료");
                   }
                 } catch (e) {
                   // 에러 처리 (예: 사용자 재인증 필요 등)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,14 +9,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.41"
-  animated_text_kit:
-    dependency: "direct main"
-    description:
-      name: animated_text_kit
-      sha256: "37392a5376c9a1a503b02463c38bc0342ef814ddbb8f9977bc90f2a84b22fa92"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.2.2"
   ansicolor:
     dependency: transitive
     description:
@@ -65,14 +57,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
-  auto_size_text:
-    dependency: "direct main"
-    description:
-      name: auto_size_text
-      sha256: "3f5261cd3fb5f2a9ab4e2fc3fba84fd9fcaac8821f20a1d4e71f557521b22599"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #85 

## 📝작업 내용

  > 계정 탈퇴시 정보만 삭제하고 uid를 가진 Document가 지워지지 않는 문제 해결
  > 온보딩 페이지에 이미지 화질 꺠지는것 수정
