### PR TITLE
[Fix] 다른 일기 반응 처리 및 예외 처리 개선

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = 23
-        targetSdk = flutter.targetSdkVersion
+        targetSdk = 35 //flutter.targetSdkVersion
         versionCode = 109
         versionName = 109
     }

--- a/lib/view/otherDiary.dart
+++ b/lib/view/otherDiary.dart
@@ -268,41 +268,76 @@ class _OtherDiaryState extends State<OtherDiary> {
                               // 닫기 버튼
                               GestureDetector(
                                 onTap: () async {
-                                  if (reaction1) {
-                                    reactionValue = 0;
-                                  } else if (reaction2) {
-                                    reactionValue = 1;
-                                  } else if (reaction3) {
-                                    reactionValue = 2;
-                                  }
+                                  try {
+                                    // 1. 반응값 설정
+                                    if (reaction1) {
+                                      reactionValue = 0;
+                                    } else if (reaction2) {
+                                      reactionValue = 1;
+                                    } else if (reaction3) {
+                                      reactionValue = 2;
+                                    } else {
+                                      reactionValue = -1;
+                                    }
 
-                                  if (reactionValue != -1) {
+                                    if (reactionValue == -1) return;
+
+                                    final diaryModel =
+                                        writeProvider.otherDiaryModel;
+                                    final diaryId = diaryModel.diaryId;
+                                    final userId = diaryModel.userId;
+
+                                    // 2. 로컬 저장
                                     mailController.saveLikedDiaryToLocal(
-                                        writeProvider.otherDiaryModel,
-                                        reactionValue);
+                                        diaryModel, reactionValue);
 
-                                    saveReactionInDB(
-                                        writeProvider.otherDiaryModel.diaryId,
-                                        writeProvider.otherDiaryModel.reaction,
+                                    // 3. Firestore에 반응 업데이트 (문서 존재 확인 후)
+                                    final diaryRef = FirebaseFirestore.instance
+                                        .collection('allDiary')
+                                        .doc(diaryId);
+                                    final docSnapshot = await diaryRef.get();
+
+                                    if (docSnapshot.exists) {
+                                      await saveReactionInDB(
+                                        diaryId,
+                                        diaryModel.reaction,
                                         reaction1,
                                         reaction2,
-                                        reaction3);
+                                        reaction3,
+                                      );
+                                    } else {
+                                      log("Diary document not found: $diaryId");
+                                    }
 
-                                    String fcmToken = (await FirebaseFirestore
-                                            .instance
+                                    // 4. 유저의 fcmToken 가져오기
+                                    final userDocSnapshot =
+                                        await FirebaseFirestore.instance
                                             .collection('users')
-                                            .doc(writeProvider
-                                                .otherDiaryModel.userId)
-                                            .get())
-                                        .data()?['fcmToken'];
+                                            .doc(userId)
+                                            .get();
 
-                                    alarmController.sendLikedDiaryNotification(
-                                      writeProvider.otherDiaryModel.diaryId,
-                                      fcmToken,
-                                      writeProvider.otherDiaryModel.userId,
-                                    );
+                                    final fcmToken =
+                                        userDocSnapshot.data()?['fcmToken'];
+
+                                    // 5. FCM 전송 조건 확인 후 알림 전송
+                                    if (fcmToken != null &&
+                                        fcmToken is String &&
+                                        fcmToken.isNotEmpty) {
+                                      alarmController
+                                          .sendLikedDiaryNotification(
+                                        diaryId,
+                                        fcmToken,
+                                        userId,
+                                      );
+                                    } else {
+                                      log("Invalid or missing FCM token for user: $userId");
+                                    }
+                                  } catch (e, stack) {
+                                    log("Error in reaction process: $e\n$stack");
+                                  } finally {
+                                    // 6. 페이지 닫기 (성공/실패 상관없이 항상 수행)
+                                    writeProvider.offDiaryOpen();
                                   }
-                                  writeProvider.offDiaryOpen();
                                 },
                                 child: PhosphorIcon(
                                   PhosphorIcons.x(),
@@ -428,17 +463,42 @@ class _OtherDiaryState extends State<OtherDiary> {
   }
 }
 
-Future<void> saveReactionInDB(String diaryId, List currReaction, bool reaction1,
-    bool reaction2, bool reaction3) async {
-  int newReaction1 = currReaction[0];
-  int newReaction2 = currReaction[1];
-  int newReaction3 = currReaction[2];
-  if (reaction1) newReaction1++;
-  if (reaction2) newReaction2++;
-  if (reaction3) newReaction3++;
+Future<void> saveReactionInDB(
+  String diaryId,
+  List currReaction,
+  bool reaction1,
+  bool reaction2,
+  bool reaction3,
+) async {
+  try {
+    if (currReaction.length != 3) {
+      log("currReaction does not have 3 elements: $currReaction");
+      return;
+    }
 
-  final FirebaseFirestore firestore = FirebaseFirestore.instance;
-  await firestore.collection('allDiary').doc(diaryId).update({
-    'reaction': [newReaction1, newReaction2, newReaction3]
-  });
+    int newReaction1 = currReaction[0] ?? 0;
+    int newReaction2 = currReaction[1] ?? 0;
+    int newReaction3 = currReaction[2] ?? 0;
+
+    if (reaction1) newReaction1++;
+    if (reaction2) newReaction2++;
+    if (reaction3) newReaction3++;
+
+    final firestore = FirebaseFirestore.instance;
+    final docRef = firestore.collection('allDiary').doc(diaryId);
+
+    final docSnapshot = await docRef.get();
+    if (!docSnapshot.exists) {
+      log("Diary document not found in saveReactionInDB: $diaryId");
+      return;
+    }
+
+    await docRef.update({
+      'reaction': [newReaction1, newReaction2, newReaction3]
+    });
+
+    log("Reaction updated in Firestore: [$newReaction1, $newReaction2, $newReaction3]");
+  } catch (e, stack) {
+    log("Error in saveReactionInDB: $e\n$stack");
+  }
 }


### PR DESCRIPTION
반응 처리 로직에 문서 존재 여부 확인, FCM 토큰 검증, 예외 처리를 추가하고 saveReactionInDB에 입력 검증과 로그를 보강함. targetSdk를 35로 업데이트함.

## #️⃣연관된 이슈

> #154 #127 

## 📝작업 내용

> 다른 일기 반응 처리 로직에 문서 존재 여부 확인 기능 추가
> FCM 토큰 유효성 검사 및 예외 처리 강화
> saveReactionInDB 함수에 입력 검증과 로그 기능 보완
> Android targetSdkVersion을 35로 업데이트

### 스크린샷 (선택)
<img width="300" height="44" alt="image" src="https://github.com/user-attachments/assets/4e6812ce-f99f-4aa7-a712-a904856e650a" />

## 💬리뷰 요구사항(선택)

> saveReactionInDB 함수 내부 예외 처리 부분에 대해 더 나은 개선점이 있을지 검토 부탁드립니다.
> 반응 처리 로직의 흐름이 명확한지 확인해주시면 감사하겠습니다.
