### PR TITLE
[Fix] Ai Chat data load error fix

### DIFF
--- a/lib/view/diary_ai_chat/diary_ai_chat_view.dart
+++ b/lib/view/diary_ai_chat/diary_ai_chat_view.dart
@@ -3,8 +3,10 @@ import 'package:bandi_official/components/dialogue/dialogue.dart';
 import 'package:bandi_official/components/no_reuse/chat_message_bar.dart';
 import 'package:bandi_official/components/dialogue/reset_dialogue.dart';
 import 'package:bandi_official/controller/diary_ai_chat_controller.dart';
+import 'package:bandi_official/model/diary_ai_chat.dart';
 import 'package:bandi_official/string_extention.dart';
 import 'package:bandi_official/theme/custom_theme_data.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/material.dart';
@@ -34,7 +36,9 @@ class _DiaryAIChatPageState extends State<DiaryAIChatPage> {
             diaryAiChatController.chatScrollController
                 .addListener(_scrollListener);
             diaryAiChatController.toggleIsListenerAdded(true);
-            diaryAiChatController.chatLogInitialization(context);
+            if (!diaryAiChatController.sendFirstMessage) {
+              diaryAiChatController.chatLogInitialization(context);
+            }
           });
         }
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,6 @@ flutter:
    - assets/config/
    - assets/bgm/
    - assets/lang/
-   - assets/screenshots
 
 fonts:
   - family: IBMPlexSansKR


### PR DESCRIPTION
ai chat view 내부 initState() 단계의 채팅 기록 불러오기와 초기 채팅 초기화간의 논리 순서 문제 수정

## #️⃣연관된 이슈

> #166 

## 📝작업 내용

> ai chat view의 initState() 순서의 채팅 로컬 저장소 불러오기와 채팅 초기화 논리 간의 오류 확인 및 수정 진행

### 스크린샷 (선택)
<img width="300" height="860" alt="ai chat bug fix" src="https://github.com/user-attachments/assets/5acbf0f7-14e4-47c4-a35d-240774c69324" />

## 💬리뷰 요구사항(선택)

> 앱 사용중 ai chat 재입장, 채팅 초기화 및 대화 진행 마지막으로 앱 종료 후 재실행시 ai chat 동작 확인 진행
> 그 외의 동작이나 오류 발생 가능성에 대한 테스트 필요
