### PR TITLE
[Fix] other diary reaction alarm error fix

### DIFF
--- a/lib/view/otherDiary.dart
+++ b/lib/view/otherDiary.dart
@@ -32,6 +32,7 @@ class _OtherDiaryState extends State<OtherDiary> {
 
   bool isKorean = true;
   bool isLoading = false;
+  bool isAlarmSendOnce = false;
   String originalLang = 'KO'; // 초기 언어 ('KO' or 'EN')
   String translatedContent = '';
   String translatedTitle = '';
@@ -321,9 +322,11 @@ class _OtherDiaryState extends State<OtherDiary> {
                                         userDocSnapshot.data()?['fcmToken'];
 
                                     // 5. FCM 전송 조건 확인 후 알림 전송
-                                    if (fcmToken != null &&
+                                    if (!isAlarmSendOnce &&
+                                        fcmToken != null &&
                                         fcmToken is String &&
                                         fcmToken.isNotEmpty) {
+                                      isAlarmSendOnce = true;
                                       alarmController
                                           .sendLikedDiaryNotification(
                                         diaryId,


### PR DESCRIPTION
- 공감 일기 페이지 닫기 시 버튼 클릭 횟수에 따른 알람 중복 전송 문제 수정

## #️⃣연관된 이슈

> #164 

## 📝작업 내용

> 공감 일기 닫기 시(닫기 버튼 터치) 버튼 동작 횟수에 따라 알람이 중복 전송되는 문제 수정

## 💬리뷰 요구사항(선택)

> 닫기 버튼 하위의 여러 함수의 경우 알람 전송을 제외하고 한 번 실행을 보장하도록 수정하진 않았습니다. 코드 리뷰 후에 알람 전송 함수 외에도 중복 실행을 방지할 필요가 있다면 추가적인 수정이 필요할 듯합니다.
