### PR TITLE
Feat(analytics): 다른 기록 열람(other_journal_search) 로깅 추가

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -49,8 +49,8 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = 23
         targetSdk = 35 //flutter.targetSdkVersion
-        versionCode = 115
-        versionName = 115
+        versionCode = 119
+        versionName = 119
         externalNativeBuild {
             // For ndk-build, instead use the ndkBuild block.
             cmake {
@@ -90,4 +90,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    implementation 'com.google.firebase:firebase-analytics-ktx'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:value="false" />
         <meta-data
             android:name="firebase_analytics_collection_enabled"
-            android:value="false" />
+            android:value="true" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -22,7 +22,7 @@ plugins {
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
 }
 
 include ":app"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -17,7 +17,7 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.1.5</string>
+		<string>1.1.9</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 			</dict>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.1.5</string>
+		<string>1.1.9</string>
 		<key>FirebaseAppDelegateProxyEnabled</key>
 		<false/>
 		<key>NSAppTransportSecurity</key>

--- a/lib/analytics/log_ai_chat_send.dart
+++ b/lib/analytics/log_ai_chat_send.dart
@@ -1,0 +1,17 @@
+import 'dart:developer';
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+final analytics = FirebaseAnalytics.instance;
+
+Future<void> logAIChatSend(
+    {required bool chatSend, required int chatLength}) async {
+  log('$chatSend and $chatLength');
+  await FirebaseAnalytics.instance.logEvent(
+    name: 'ai_chat_send',
+    parameters: {
+      'message_send': chatSend ? 'yes' : 'no',
+      'message_length': chatLength,
+    },
+  );
+}

--- a/lib/analytics/log_ai_chat_send.dart
+++ b/lib/analytics/log_ai_chat_send.dart
@@ -1,12 +1,9 @@
-import 'dart:developer';
-
 import 'package:firebase_analytics/firebase_analytics.dart';
 
 final analytics = FirebaseAnalytics.instance;
 
 Future<void> logAIChatSend(
     {required bool chatSend, required int chatLength}) async {
-  log('$chatSend and $chatLength');
   await FirebaseAnalytics.instance.logEvent(
     name: 'ai_chat_send',
     parameters: {

--- a/lib/analytics/log_other_journal_search.dart
+++ b/lib/analytics/log_other_journal_search.dart
@@ -1,0 +1,12 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+final analytics = FirebaseAnalytics.instance;
+
+Future<void> logOtherJournalSearch({required String journalType}) async {
+  await analytics.logEvent(
+    name: 'other_journal_search',
+    parameters: {
+      'journal_type': journalType, // e.g. 'others', 'letters'
+    },
+  );
+}

--- a/lib/controller/diary_ai_chat_controller.dart
+++ b/lib/controller/diary_ai_chat_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:bandi_official/analytics/log_ai_chat_send.dart';
 import 'package:bandi_official/model/diary_ai_chat.dart';
 import 'package:bandi_official/string_extention.dart';
 import 'package:bandi_official/utils/time_utils.dart';
@@ -25,6 +26,8 @@ class DiaryAiChatController with ChangeNotifier {
   FocusNode chatFocusNode = FocusNode();
   // determine whether to display the recommended message
   bool sendFirstMessage = false;
+  // determine whether chat is used for one app life cycle
+  bool sendFirstMessageForAnalysis = false;
   // while the ai answering the message
   bool isChatResponsLoading = false;
   // determine whether to display the chat view
@@ -76,6 +79,10 @@ class DiaryAiChatController with ChangeNotifier {
   void toggleIsListenerAdded(value) {
     isListenerAdded = value;
     notifyListeners();
+  }
+
+  void toggleChatAnalysis(bool value) {
+    sendFirstMessageForAnalysis = value;
   }
 
   // toggle the message send button while the gpt respoonse loading
@@ -214,7 +221,6 @@ class DiaryAiChatController with ChangeNotifier {
     updateUserChat();
     chatlog.add(chatModel);
     scrollChatScreenToBottom();
-    chatTextController.clear();
 
     // call chatGPT response
     getResponse(context).then((value) {
@@ -222,6 +228,13 @@ class DiaryAiChatController with ChangeNotifier {
       // save the chat log to the local storage
       saveChatLogToLocal();
     });
+
+    if (!sendFirstMessageForAnalysis) {
+      logAIChatSend(chatSend: true, chatLength: chatTextController.text.length);
+      toggleChatAnalysis(true);
+    }
+
+    chatTextController.clear();
 
     notifyListeners();
   }
@@ -236,6 +249,7 @@ class DiaryAiChatController with ChangeNotifier {
   void resetTheChat(BuildContext context) {
     if (sendFirstMessage && !isChatResponsLoading) {
       sendFirstMessage = false;
+      toggleChatAnalysis(false);
 
       // reset the chatlog (visible chat)
       chatlog = ChatMessage.defaultChatLog(context);

--- a/lib/view/mail/letters_view.dart
+++ b/lib/view/mail/letters_view.dart
@@ -1,3 +1,4 @@
+import 'package:bandi_official/analytics/log_other_journal_search.dart';
 import 'package:bandi_official/components/loading/loading_page.dart';
 import 'package:bandi_official/controller/mail_controller.dart';
 import 'package:bandi_official/model/letter.dart';
@@ -99,6 +100,7 @@ Widget lettersWidget(
     padding: const EdgeInsets.symmetric(vertical: 8),
     child: GestureDetector(
       onTap: () {
+        logOtherJournalSearch(journalType: 'letters');
         mailController.toggleDetailView(true);
         showDialog(
           context: context,

--- a/lib/view/mail/liked_diary_view.dart
+++ b/lib/view/mail/liked_diary_view.dart
@@ -1,3 +1,4 @@
+import 'package:bandi_official/analytics/log_other_journal_search.dart';
 import 'package:bandi_official/components/loading/loading_page.dart';
 import 'package:bandi_official/controller/mail_controller.dart';
 import 'package:bandi_official/model/diary.dart';
@@ -167,6 +168,7 @@ Widget likedDiaryWidget(
           child: GestureDetector(
             // 일기 열람 기능 추가
             onTap: () {
+              logOtherJournalSearch(journalType: 'others');
               mailController.toggleDetailView(true);
               showDialog(
                 context: context,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #175 

## 📝작업 내용

> other_journal_search 로깅 추가
* journal_type: 열람하는 다른 기록 유형 (others: 다른 유저의 일기, letters: 월간 편지)

```
Future<void> logOtherJournalSearch({required String journalType}) async {
  await analytics.logEvent(
    name: 'other_journal_search',
    parameters: {
      'journal_type': journalType, // e.g. 'others', 'letters'
    },
  );
}
```

### 스크린샷 (선택)

<img width="1440" height="765" alt="image" src="https://github.com/user-attachments/assets/67d4cc6b-5561-42f6-a55d-ae6a02e3299f" />

## 💬리뷰 요구사항(선택)

> 안드로이드 기기를 통해 firebase debug view 작동 여부 확인
> 보관함에서 다른 유저의 기록 혹은 편지의 detail_view를 이동할 때마다 로깅 진행