### PR TITLE
Feat(analytics): 알람 실행 여부(notification_open) 로깅 추가

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -49,8 +49,8 @@ android {
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = 23
         targetSdk = 35 //flutter.targetSdkVersion
-        versionCode = 115
-        versionName = 115
+        versionCode = 119
+        versionName = 119
         externalNativeBuild {
             // For ndk-build, instead use the ndkBuild block.
             cmake {
@@ -90,4 +90,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    implementation 'com.google.firebase:firebase-analytics-ktx'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:value="false" />
         <meta-data
             android:name="firebase_analytics_collection_enabled"
-            android:value="false" />
+            android:value="true" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -22,7 +22,7 @@ plugins {
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
 }
 
 include ":app"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -17,7 +17,7 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.1.5</string>
+		<string>1.1.9</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleURLTypes</key>
@@ -32,7 +32,7 @@
 			</dict>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>1.1.5</string>
+		<string>1.1.9</string>
 		<key>FirebaseAppDelegateProxyEnabled</key>
 		<false/>
 		<key>NSAppTransportSecurity</key>

--- a/lib/analytics/log_ai_chat_send.dart
+++ b/lib/analytics/log_ai_chat_send.dart
@@ -1,0 +1,17 @@
+import 'dart:developer';
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+final analytics = FirebaseAnalytics.instance;
+
+Future<void> logAIChatSend(
+    {required bool chatSend, required int chatLength}) async {
+  log('$chatSend and $chatLength');
+  await FirebaseAnalytics.instance.logEvent(
+    name: 'ai_chat_send',
+    parameters: {
+      'message_send': chatSend ? 'yes' : 'no',
+      'message_length': chatLength,
+    },
+  );
+}

--- a/lib/analytics/log_ai_chat_send.dart
+++ b/lib/analytics/log_ai_chat_send.dart
@@ -1,12 +1,9 @@
-import 'dart:developer';
-
 import 'package:firebase_analytics/firebase_analytics.dart';
 
 final analytics = FirebaseAnalytics.instance;
 
 Future<void> logAIChatSend(
     {required bool chatSend, required int chatLength}) async {
-  log('$chatSend and $chatLength');
   await FirebaseAnalytics.instance.logEvent(
     name: 'ai_chat_send',
     parameters: {

--- a/lib/analytics/log_notification_open.dart
+++ b/lib/analytics/log_notification_open.dart
@@ -1,0 +1,39 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+final analytics = FirebaseAnalytics.instance;
+
+// 알람 수신 시 (미사용)
+Future<void> logNotificationReceive({required String campaignId}) async {
+  await analytics.logEvent(
+    name: 'notification_receive',
+    parameters: {'campaign_id': campaignId},
+  );
+}
+
+// 알람 클릭 시 (앱이 열릴 때)
+Future<void> logNotificationOpen({
+  required String campaignId,
+  required String destination,
+}) async {
+  await analytics.logEvent(
+    name: 'notification_open',
+    parameters: {
+      'campaign_id': campaignId,
+      'destination': destination, // e.g. 'letter_detail', 'liked_diary_detail'
+    },
+  );
+}
+
+// 딥링크 진입 시 (미사용, destination의 경우 알람 클릭시 이동 페이지까지 파악 가능)
+Future<void> logPushDeeplinkOpen({
+  required String campaignId,
+  required String destination,
+}) async {
+  await analytics.logEvent(
+    name: 'push_deeplink_open',
+    parameters: {
+      'campaign_id': campaignId,
+      'destination': destination // e.g. 'letter_detail', 'liked_diary_detail'
+    },
+  );
+}

--- a/lib/analytics/log_other_journal_search.dart
+++ b/lib/analytics/log_other_journal_search.dart
@@ -1,0 +1,12 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+
+final analytics = FirebaseAnalytics.instance;
+
+Future<void> logOtherJournalSearch({required String journalType}) async {
+  await analytics.logEvent(
+    name: 'other_journal_search',
+    parameters: {
+      'journal_type': journalType, // e.g. 'others', 'letters'
+    },
+  );
+}

--- a/lib/controller/alarm_controller.dart
+++ b/lib/controller/alarm_controller.dart
@@ -1,4 +1,4 @@
-import 'package:bandi_official/controller/emotion_provider.dart';
+import 'package:bandi_official/analytics/log_notification_open.dart';
 import 'package:bandi_official/controller/home_to_write.dart';
 import 'package:bandi_official/controller/mail_controller.dart';
 import 'package:bandi_official/controller/navigation_toggle_provider.dart';
@@ -69,7 +69,7 @@ class AlarmController with ChangeNotifier {
   // foreground notification receive
   void firebaseOnMessageListen() async {
     dev.log('foreground message setting done');
-    FirebaseMessaging.onMessage.listen((RemoteMessage? message) {
+    FirebaseMessaging.onMessage.listen((RemoteMessage? message) async {
       if (message != null && message.notification != null) {
         dev.log('local message received');
         WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -99,9 +99,14 @@ class AlarmController with ChangeNotifier {
         final screen = message.data['screen'];
         final letterId = message.data['letterId'] ?? '';
         final likedDiaryDetail = message.data['likedDiaryId'] ?? '';
+        const campaignId = "notification_open_v1";
 
-        final payload = '$screen/$letterId/$likedDiaryDetail';
+        final payload = '$screen/$letterId/$likedDiaryDetail/$campaignId';
 
+        // 알람 송신 여부 로깅
+        /*
+          await logNotificationReceive(campaignId: campaignId);
+        */
         _local.show(1, message.notification!.title!,
             message.notification!.body!, details,
             payload: payload);
@@ -112,7 +117,7 @@ class AlarmController with ChangeNotifier {
   // background notification receive
   void firebaseOnMessageOpenedApp() {
     dev.log('message receive interact setting done');
-    FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+    FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) async {
       if (message.notification != null) {
         dev.log('back ground message received');
         WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -123,6 +128,15 @@ class AlarmController with ChangeNotifier {
           mailController.updateIsNewNotifications(true);
         });
 
+        // 알람 클릭 여부 로깅
+        final campaignId = message.data['campaignId'] ?? '';
+        final destination = message.data['screen'] ?? '';
+        if (campaignId.isNotEmpty) {
+          await logNotificationOpen(
+            campaignId: campaignId,
+            destination: destination,
+          );
+        }
         messageInteractionDeclaration(message);
       }
     });
@@ -241,7 +255,17 @@ class AlarmController with ChangeNotifier {
         'screen': parts[0],
         'letterId': parts[1],
         'likedDiaryId': parts[2],
+        'campaignId': parts.length > 3 ? parts[3] : '',
       });
+      // 알람 클릭 여부 로깅
+      final campaignId = parts.length > 3 ? parts[3] : '';
+      final destination = parts[0];
+      if (campaignId.isNotEmpty) {
+        logNotificationOpen(
+          campaignId: campaignId,
+          destination: destination,
+        );
+      }
       messageInteractionDeclaration(remoteMessage);
     }
   }

--- a/lib/controller/diary_ai_chat_controller.dart
+++ b/lib/controller/diary_ai_chat_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:bandi_official/analytics/log_ai_chat_send.dart';
 import 'package:bandi_official/model/diary_ai_chat.dart';
 import 'package:bandi_official/string_extention.dart';
 import 'package:bandi_official/utils/time_utils.dart';
@@ -25,6 +26,8 @@ class DiaryAiChatController with ChangeNotifier {
   FocusNode chatFocusNode = FocusNode();
   // determine whether to display the recommended message
   bool sendFirstMessage = false;
+  // determine whether chat is used for one app life cycle
+  bool sendFirstMessageForAnalysis = false;
   // while the ai answering the message
   bool isChatResponsLoading = false;
   // determine whether to display the chat view
@@ -76,6 +79,10 @@ class DiaryAiChatController with ChangeNotifier {
   void toggleIsListenerAdded(value) {
     isListenerAdded = value;
     notifyListeners();
+  }
+
+  void toggleChatAnalysis(bool value) {
+    sendFirstMessageForAnalysis = value;
   }
 
   // toggle the message send button while the gpt respoonse loading
@@ -214,7 +221,6 @@ class DiaryAiChatController with ChangeNotifier {
     updateUserChat();
     chatlog.add(chatModel);
     scrollChatScreenToBottom();
-    chatTextController.clear();
 
     // call chatGPT response
     getResponse(context).then((value) {
@@ -222,6 +228,13 @@ class DiaryAiChatController with ChangeNotifier {
       // save the chat log to the local storage
       saveChatLogToLocal();
     });
+
+    if (!sendFirstMessageForAnalysis) {
+      logAIChatSend(chatSend: true, chatLength: chatTextController.text.length);
+      toggleChatAnalysis(true);
+    }
+
+    chatTextController.clear();
 
     notifyListeners();
   }
@@ -236,6 +249,7 @@ class DiaryAiChatController with ChangeNotifier {
   void resetTheChat(BuildContext context) {
     if (sendFirstMessage && !isChatResponsLoading) {
       sendFirstMessage = false;
+      toggleChatAnalysis(false);
 
       // reset the chatlog (visible chat)
       chatlog = ChatMessage.defaultChatLog(context);

--- a/lib/view/mail/letters_view.dart
+++ b/lib/view/mail/letters_view.dart
@@ -1,3 +1,4 @@
+import 'package:bandi_official/analytics/log_other_journal_search.dart';
 import 'package:bandi_official/components/loading/loading_page.dart';
 import 'package:bandi_official/controller/mail_controller.dart';
 import 'package:bandi_official/model/letter.dart';
@@ -99,6 +100,7 @@ Widget lettersWidget(
     padding: const EdgeInsets.symmetric(vertical: 8),
     child: GestureDetector(
       onTap: () {
+        logOtherJournalSearch(journalType: 'letters');
         mailController.toggleDetailView(true);
         showDialog(
           context: context,

--- a/lib/view/mail/liked_diary_view.dart
+++ b/lib/view/mail/liked_diary_view.dart
@@ -1,3 +1,4 @@
+import 'package:bandi_official/analytics/log_other_journal_search.dart';
 import 'package:bandi_official/components/loading/loading_page.dart';
 import 'package:bandi_official/controller/mail_controller.dart';
 import 'package:bandi_official/model/diary.dart';
@@ -167,6 +168,7 @@ Widget likedDiaryWidget(
           child: GestureDetector(
             // 일기 열람 기능 추가
             onTap: () {
+              logOtherJournalSearch(journalType: 'others');
               mailController.toggleDetailView(true);
               showDialog(
                 context: context,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #176 

## 📝작업 내용

> notification_open 로깅 추가 (FCM을 통한 알람 및 로컬 알람을 통한 앱 실행 여부 로깅)
* campaign_id: 로깅 유형별 id (현재 'notification_open_v1'로 통일)
* destination: 알람 클릭을 통해 이동하는 페이지 (letter_detail, liked_diary_detail)

```
// 알람 클릭 시 (앱이 열릴 때)
Future<void> logNotificationOpen({
  required String campaignId,
  required String destination,
}) async {
  await analytics.logEvent(
    name: 'notification_open',
    parameters: {
      'campaign_id': campaignId,
      'destination': destination, // e.g. 'letter_detail', 'liked_diary_detail'
    },
  );
}
```

### 스크린샷 (선택)

> 알람 송수신에 관한 테스트 필요 (개인으로 테스트의 어려움)

## 💬리뷰 요구사항(선택)

> 코드 구조상 문제는 없을 것으로 보이나 추후 2개 이상의 기기에서 알람 송수신을 통한 검증이 추가적으로 필요함
> 알람 송신에 관한 로깅 코드를 구현했으나 기존의 FCM을 통한 데이터 수집 및 로깅 횟수와 관련된 이슈로 주석 처리한 상황

```
Future<void> logNotificationReceive({required String campaignId}) async {
  await analytics.logEvent(
    name: 'notification_receive',
    parameters: {'campaign_id': campaignId},
  );
}
```