### PR TITLE
Feat(analytics): 반디와 대화하기(ai_chat_send_count) 로깅 수정

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1639,18 +1639,18 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   abseil: a05cc83bf02079535e17169a73c5be5ba47f714b
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
-  assets_audio_player: edee322b9cb625571b830b35872ead1a295fd917
-  assets_audio_player_web: 19826380c44375761aa0b9053665c1e3fbc3b86b
+  assets_audio_player: ae418728ee1b31f11556504fda8034639e20ce44
+  assets_audio_player_web: ce9341347867b03c2eb749d927e18ec009dbe763
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 97e42181866db3cba3fe3935895ab779b6acacd6
-  cloud_functions: 614444590e43b7567dc7f57e6027cb15ab4a2c0e
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
+  cloud_firestore: fdcc87898326e396d6ef6df543acf9b5c2034b95
+  cloud_functions: 8565a870fbdc2b5046cba8183e972484128b6d8d
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
   Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
-  firebase_analytics: bf93e20703c95030404d6ddbb1adf05bf5c3885b
-  firebase_auth: 5342db41af2ba5ed32a6177d9e326eecbebda912
-  firebase_core: 99a37263b3c27536063a7b601d9e2a49400a433c
-  firebase_messaging: bf6697c61f31c7cc0f654131212ff04c0115c2c7
-  firebase_storage: df33afa2324a7c6c444eba802576f1b1ba7a8108
+  firebase_analytics: 0e25ca1d4001ccedd40b4e5b74c0ec34e18f6425
+  firebase_auth: 50af8366c87bb88c80ebeae62eb60189c7246b9b
+  firebase_core: 995454a784ff288be5689b796deb9e9fa3601818
+  firebase_messaging: f4a41dd102ac18b840eba3f39d67e77922d3f707
+  firebase_storage: 1144b3236855c52ff52741b12374862ee84d5a28
   FirebaseAnalytics: 6433dfd311ba78084fc93bdfc145e8cb75740eae
   FirebaseAppCheckInterop: 06fe5a3799278ae4667e6c432edd86b1030fa3df
   FirebaseAuth: a6575e5fbf46b046c58dc211a28a5fbdd8d4c83b
@@ -1667,11 +1667,11 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
   FirebaseStorage: 50fc9ee147392943e492467db6b52759b0447037
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_app_badge_control: d6d75b551276415000614b684822333bffac200b
-  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
-  flutter_native_splash: edf599c81f74d093a4daf8e17bd7a018854bc778
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  google_sign_in_ios: 07375bfbf2620bc93a602c0e27160d6afc6ead38
+  flutter_app_badge_control: 1f0ac37334d1a2da72bde7e4d3c6c8675517a471
+  flutter_local_notifications: ad39620c743ea4c15127860f4b5641649a988100
+  flutter_native_splash: 35ddbc7228eafcb3969dcc5f1fbbe27c1145a4f0
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  google_sign_in_ios: 0ab078e60da6dfe23cbc55c83502b52bba1aad63
   GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64
   GoogleAppMeasurement: 700dce7541804bec33db590a5c496b663fbe2539
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
@@ -1683,13 +1683,13 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
 
 PODFILE CHECKSUM: 6e6a4caaeb7656ac595ec40765542a8591c3cd4b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/lib/analytics/log_ai_chat_send.dart
+++ b/lib/analytics/log_ai_chat_send.dart
@@ -2,13 +2,13 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 
 final analytics = FirebaseAnalytics.instance;
 
-Future<void> logAIChatSend(
-    {required bool chatSend, required int chatLength}) async {
+Future<void> logAIChatSendCount(
+    {required int chatLengthCount, required int chatResetCount}) async {
   await FirebaseAnalytics.instance.logEvent(
-    name: 'ai_chat_send',
+    name: 'ai_chat_send_count',
     parameters: {
-      'message_send': chatSend ? 'yes' : 'no',
-      'message_length': chatLength,
+      'message_length_count': chatLengthCount,
+      'message_reset_count': chatResetCount,
     },
   );
 }

--- a/lib/controller/diary_ai_chat_controller.dart
+++ b/lib/controller/diary_ai_chat_controller.dart
@@ -26,8 +26,10 @@ class DiaryAiChatController with ChangeNotifier {
   FocusNode chatFocusNode = FocusNode();
   // determine whether to display the recommended message
   bool sendFirstMessage = false;
-  // determine whether chat is used for one app life cycle
-  bool sendFirstMessageForAnalysis = false;
+  // count chat message for one chatting
+  int countMessageForAnalysis = 0;
+  // count chat reset for analysis
+  int countMessageResetForAnalysis = 0;
   // while the ai answering the message
   bool isChatResponsLoading = false;
   // determine whether to display the chat view
@@ -66,6 +68,13 @@ class DiaryAiChatController with ChangeNotifier {
   // toggle the chat page view
   void toggleChatOpen(value) {
     isChatOpen = value;
+    if (!isChatOpen && countMessageForAnalysis != 0) {
+      logAIChatSendCount(
+          chatLengthCount: countMessageForAnalysis,
+          chatResetCount: countMessageResetForAnalysis);
+      initializeCountChatAnalysis();
+      initializeCountMessageResetForAnalysisAnalysis();
+    }
     notifyListeners();
   }
 
@@ -81,8 +90,26 @@ class DiaryAiChatController with ChangeNotifier {
     notifyListeners();
   }
 
-  void toggleChatAnalysis(bool value) {
-    sendFirstMessageForAnalysis = value;
+  // make count value for analysis to 0
+  void initializeCountChatAnalysis() {
+    countMessageForAnalysis = 0;
+    notifyListeners();
+  }
+
+  // make reset count value for analysis to 0
+  void initializeCountMessageResetForAnalysisAnalysis() {
+    countMessageResetForAnalysis = 0;
+    notifyListeners();
+  }
+
+  // increase count value for analysis
+  void countChatAnalysis() {
+    countMessageForAnalysis++;
+  }
+
+  // increase reset count value for analysis
+  void countMessageResetForAnalysisAnalysis() {
+    countMessageResetForAnalysis++;
   }
 
   // toggle the message send button while the gpt respoonse loading
@@ -206,6 +233,8 @@ class DiaryAiChatController with ChangeNotifier {
       sendFirstMessage = true;
     }
 
+    countChatAnalysis();
+
     // dev.log(chatlog.last.messageTime.toString());
 
     // when submitted message's date is different with latest message's date
@@ -229,11 +258,6 @@ class DiaryAiChatController with ChangeNotifier {
       saveChatLogToLocal();
     });
 
-    if (!sendFirstMessageForAnalysis) {
-      logAIChatSend(chatSend: true, chatLength: chatTextController.text.length);
-      toggleChatAnalysis(true);
-    }
-
     chatTextController.clear();
 
     notifyListeners();
@@ -249,7 +273,7 @@ class DiaryAiChatController with ChangeNotifier {
   void resetTheChat(BuildContext context) {
     if (sendFirstMessage && !isChatResponsLoading) {
       sendFirstMessage = false;
-      toggleChatAnalysis(false);
+      countMessageResetForAnalysisAnalysis();
 
       // reset the chatlog (visible chat)
       chatlog = ChatMessage.defaultChatLog(context);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #184 

## 📝작업 내용

> 기존의 채팅 길이를 제외한 1번의 채팅 세션에서 이뤄지는 채팅의 횟수, 초기화 횟수를 카운팅 하도록 변경
* message_length_count: 한 번의 채팅 세션에서 보내진 유저의 채팅 횟수
* message_reset_count: 한 번의 채팅 세션에서 발생한 채팅 리셋 횟수, 단 채팅 없이 초기화만 이뤄진 경우는 수집하지 않음

```
Future<void> logAIChatSendCount(
    {required int chatLengthCount, required int chatResetCount}) async {
  await FirebaseAnalytics.instance.logEvent(
    name: 'ai_chat_send_count',
    parameters: {
      'message_length_count': chatLengthCount,
      'message_reset_count': chatResetCount,
    },
  );
}
```

### 스크린샷 (선택)
<img src="{url}" width="300"/>    
<img width="1440" height="772" alt="image" src="https://github.com/user-attachments/assets/a4d99395-88e7-40be-8004-76007faff163" />